### PR TITLE
Fix typo in mxGraph touch event docs

### DIFF
--- a/js/diagrams/src/js/view/mxGraph.js
+++ b/js/diagrams/src/js/view/mxGraph.js
@@ -916,14 +916,14 @@ mxGraph.prototype.tapAndHoldValid = false;
 /**
  * Variable: initialTouchX
  * 
- * Holds the x-coordinate of the intial touch event for tap and hold.
+ * Holds the x-coordinate of the initial touch event for tap and hold.
  */
 mxGraph.prototype.initialTouchX = 0;
 
 /**
  * Variable: initialTouchY
  * 
- * Holds the y-coordinate of the intial touch event for tap and hold.
+ * Holds the y-coordinate of the initial touch event for tap and hold.
  */
 mxGraph.prototype.initialTouchY = 0;
 


### PR DESCRIPTION
## Summary
- fix typo for `initialTouchX`/`initialTouchY` comments

## Testing
- `echo "No tests present" && true`